### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/shacharmirkin/shacharmirkin.github.io/security/code-scanning/1](https://github.com/shacharmirkin/shacharmirkin.github.io/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `verify`) unless overridden.  
For this workflow, the minimal least-privilege baseline is:

- `contents: read`

This preserves existing functionality for checkout/build/test while limiting token capabilities.

Change region: right after the `on:` trigger block and before `jobs:` (between current lines 7 and 8 in the snippet).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
